### PR TITLE
Fix for parsing on OS X

### DIFF
--- a/lib/docpad.coffee
+++ b/lib/docpad.coffee
@@ -39,6 +39,8 @@ Date::toISODateString = Date::toIsoDateString = ->
 		pad(@getUTCMinutes())+':'+
 		pad(@getUTCSeconds())+'Z'
 
+String::startsWith = (prefix) ->
+	return @indexOf(prefix) is 0
 
 # -------------------------------------
 # Main


### PR DESCRIPTION
Just getting started with DocPad (and CoffeScript for that matter). Like what I see so far, and I'm eager to try to help evolve DocPad.

Ran in to a problem with DocPad parsing on OSX. The parser was picking-up hidden system files (specifically .DS_Store), causing unexpected results (such as ".DS_Store" being listed as a blog post file).

To prevent that behavior, I added check to ignore hidden system files that start with "." (such as .DS_Store on Mac). In general, hidden files (which generally start with ".") should be ignored by the parser to prevent including them in the @Documents/@Layouts collections.

Hope this helps.
