### PR TITLE
use node-discount replace gfm & fix a bug.

### DIFF
--- a/lib/docpad.coffee
+++ b/lib/docpad.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 sys = require 'sys'
 express = false
 yaml = false
-gfm = false
+md = false
 jade = false
 eco = false
 watchTree = false
@@ -180,7 +180,7 @@ class Docpad
 		# Requires
 		util = require 'bal-util'  unless util
 		yaml = require 'yaml'  unless yaml
-		gfm = require 'github-flavored-markdown'  unless gfm
+		md = require 'discount'  unless md
 		jade = require 'jade'  unless jade
 		
 		# Prepare
@@ -209,7 +209,7 @@ class Docpad
 				# Handle data
 				fileData = data.toString()
 				fileSplit = fileData.split '---'
-				if fileSplit.length is 3 and !fileSplit[0]
+				if fileSplit.length >= 3 and !fileSplit[0]
 					# Extract parts
 					fileHead = fileSplit[1].replace(/\t/g,'    ').replace(/\s+$/m,'').replace(/\r\n?/g,'\n')+'\n'
 					fileBody = fileSplit.slice(2).join('---')
@@ -224,7 +224,7 @@ class Docpad
 					when '.jade'
 						result = jade.render fileBody
 					when '.md'
-						fileMeta.content = gfm.parse fileBody
+						fileMeta.content = md.parse fileBody
 					else
 						fileMeta.content = fileBody
 				

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "docpad",
-	"version": "0.9.18",
+	"version": "0.9.19",
 	"description": "DocPad (like Jekyll) is a static website generator, unlike Jekyll it's written in CoffeeScript+Node.js instead of Ruby, and also allows the template engine complete access to the document model. This means you have unlimited power as a CMS and the simplicity of a notepad.",
 	"homepage": "https://github.com/balupton/docpad",
 	"keywords": [
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"query-engine": ">=0.2.2",
-		"github-flavored-markdown": ">=1.0.0",
+		"discount": ">=0.1.3",
 		"jade": ">=0.12.4",
 		"eco": ">=1.0.0",
 		"express": ">=2.4.2",


### PR DESCRIPTION
Feature:
Use node-discount replace github-flavored-markdown to support table syntax.

Bug fix:
When I use '---' in my markdown file, the content after '---' will lose. so, I fixed it.
