### PR TITLE
Changing the docpad.action method

### DIFF
--- a/lib/docpad.coffee
+++ b/lib/docpad.coffee
@@ -361,7 +361,7 @@ class Docpad
 
 
 	# Handle
-	action: (action) ->
+	action: (action, complete = -> process.exit()) ->
 		# Clear
 		if @actionTimeout
 			clearTimeout(@actionTimeout)
@@ -372,7 +372,7 @@ class Docpad
 			logger.log 'notice', 'Action received, but we still loading... waiting...'
 			@actionTimeout = setTimeout(
 				=>
-					@action action
+					@action action, complete
 				500
 			)
 			return
@@ -382,12 +382,12 @@ class Docpad
 			when 'skeleton', 'scaffold'
 				@skeletonAction (err) ->
 					return @error(err)  if err
-					process.exit()
+					complete()
 
 			when 'generate'
 				@generateAction (err) ->
 					return @error(err)  if err
-					process.exit()
+					complete()
 
 			when 'watch'
 				@watchAction (err) ->


### PR DESCRIPTION
this will allow devs to use the pipeline and not have the app quit when an action completes.

Scenario -> using docpad to generate the output on app startup and then launching the server.
