### PR TITLE
Pass 'filename' option to enable Jade includes

### DIFF
--- a/lib/plugins/renderers/jade.plugin.coffee
+++ b/lib/plugins/renderers/jade.plugin.coffee
@@ -15,7 +15,9 @@ class JadePlugin extends DocpadPlugin
 	render: ({inExtension,outExtension,templateData,file}, next) ->
 		try
 			if inExtension is 'jade'
-				file.content = jade.compile(file.content, {})(templateData)
+				file.content = jade.compile(file.content, {
+					filename: file.fullPath
+				})(templateData)
 				next()
 			else if outExtension is 'jade' and inExtension is 'html'
 				html2jade.convertHtml file.content, {}, (err,result) ->


### PR DESCRIPTION
I was trying to use the "include" directive in my Jade templates, but I received the error "Error: the "filename" option is required to use includes".

This pull request fixes Jade's include directive by passing the 'filename' option to `jade.compile` in `lib/plugins/renderers/jade.plugin.coffee`.
