### PR TITLE
Support for merging a layouts `fileMeta` with the current documents during layout rendering.

### DIFF
--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -2,6 +2,7 @@
 util = require 'bal-util'
 fs = require 'fs'
 path = require 'path'
+_ = require 'underscore'
 coffee = null
 yaml = null
 js2coffee = null
@@ -292,6 +293,7 @@ class File
 				@getLayout (err,layout) =>
 					return next(err)  if err
 					templateData.content = @contentRendered
+					templateData.document = _.extend {}, layout.fileMeta, templateData.document
 					layout.render templateData, (err) =>
 						@contentRendered = layout.contentRendered
 						@logger.log 'debug', "Rendering completed for #{@relativePath}"


### PR DESCRIPTION
Now when a property of the same name is defined both in the document and the layout, the documents value is preferred, if it exists. If the property exists in the layout, but not the document, the layouts value will be used. Enabling sane defaults to be defined in the layout and overridden in the document.
