### PR TITLE
Require RubyGems on Ruby 1.8

### DIFF
--- a/lib/exchange/plugins/ruby/ruby.plugin.coffee
+++ b/lib/exchange/plugins/ruby/ruby.plugin.coffee
@@ -23,6 +23,7 @@ module.exports = (BasePlugin) ->
 						EOF
 						document = Hash.new()
 						
+            require 'rubygems' unless defined? Gem
 						require 'json'
 						document = JSON.parse <<-EOF
 						#{data}


### PR DESCRIPTION
The tests were failing miserably with system Ruby on Mac OS X.
