### PR TITLE
fix mis-typed 'logger'

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -11,7 +11,7 @@ class BasePlugin
 	docpad: null
 
 	# Logger Instance
-	docpad: null
+	logger: null
 
 
 	# ---------------------------------


### PR DESCRIPTION
You typed docpad twice in plugin.coffee. I quess one is logger.
