### PR TITLE
Update docpad for the rest plugin

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -2217,7 +2217,7 @@ class DocPad extends EventSystem
 		finish = (err) ->
 			return complete(err)  if err
 			# Plugins
-			docpad.emitSync 'serverAfter', {server}, (err) ->
+			docpad.emitSync 'serverAfter', {docpad}, (err) ->
 				return complete(err)  if err
 				# Complete
 				docpad.log 'debug', 'Server setup'


### PR DESCRIPTION
When trying to update the rest plugin, I realized that the `serverAfter` sent the `{server}` param, but the rest plugin has a signature of `{docpad,server}` and never used the `server` var. This is a small patch to send the `docpad` param instead. I think sending `server` is useless since the helper `getServer` can be used in the rest plugin (or any plugin for that matter).

The rest of my on-going work in this [pull request in the docpad-extras repo](https://github.com/bevry/docpad-extras/pull/6)
