### PR TITLE
Fixed an issue with content type being looked up twice

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -2547,7 +2547,7 @@ class DocPad extends EventEmitterEnhanced
 
 		# Content Type
 		contentType = document.get('contentTypeRendered') or document.get('contentType')
-    res.setHeader('Content-Type', contentType);
+		res.setHeader('Content-Type', contentType);
 
 		# Send
 		dynamic = document.get('dynamic')


### PR DESCRIPTION
There was a problem with the content type being set incorrectly after being looked up twice.

Initially looked up here: https://github.com/bevry/docpad/blob/master/src/lib/models/document.coffee#L363

Then looked up again from running: https://github.com/bevry/docpad/blob/master/src/lib/docpad.coffee#L2550

The contentType method provided by Express just calls mime.lookup and fails on files like JavaScript which the mime type doesn't match on application/javascript.
