### PR TITLE
Remove unnecessary growl notification.

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -2095,7 +2095,6 @@ class DocPad extends EventEmitterEnhanced
 
 		# Log generating
 		docpad.log 'info', 'Generating...'
-		docpad.notify (new Date()).toLocaleTimeString(), title: 'Website generating...'
 
 		# Fire plugins
 		docpad.emitSync 'generateBefore', server: docpad.getServer(), (err) ->


### PR DESCRIPTION
The success are error notifications are plenty of feedback. Currently each successful build you get two back to back notifications... Annoying a bit.
