### PR TITLE
Removed Model requirement in Document

### DIFF
--- a/src/lib/models/document.coffee
+++ b/src/lib/models/document.coffee
@@ -9,7 +9,6 @@ CSON = null
 yaml = null
 
 # Local
-{Model} = require(__dirname+'/../base')
 FileModel = require(__dirname+'/file')
 
 


### PR DESCRIPTION
This var is unused since DocumentModel inherits from FileModel
