### PR TITLE
removed unnecessary notify var

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -1824,7 +1824,6 @@ class DocPad extends EventEmitterEnhanced
 
 		# Prepare
 		docpad = @
-		notify = @notify
 
 		# Check
 		balUtil.packageCompare


### PR DESCRIPTION
On a side note, should growl notifications be removed from the core and turned into a plugin ?

It's kind of a mac specific functionality, for example it doesn't pop-up anything by default on the linux station I'm using.
