### PR TITLE
Allow `regenerateDelay` to be user configurable

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -665,6 +665,13 @@ class DocPad extends EventEmitterEnhanced
 		# Paths that we should watch for regeneration changes in
 		regeneratePaths: []
 
+		# The time (in milliseconds) to wait after a source
+		# file has changed before using it to regenerate. If
+		# updating a template via FTP or some other relatively
+		# slow method you might want to increase this to
+		# ensure the source is fully rendered.
+		regenerateDelay: 100
+
 		# The website's out directory
 		outPath: 'out'
 
@@ -2941,7 +2948,7 @@ class DocPad extends EventEmitterEnhanced
 
 		# Timer
 		regenerateTimer = null
-		regenerateDelay = 100
+		regenerateDelay = docpad.config.regenerateDelay
 		queueRegeneration = ->
 			# Reset the wait
 			if regenerateTimer


### PR DESCRIPTION
A new configuration option `regenerateDelay` has been added. Defaulting
to 100, this option specifies how long docpad waits after a source
file has been changed before using it to regenerate a page.

In situations where source files (especially large files) are being
updated over the network (e.g. via FTP) it can be useful to increase
this option: not doing so can cause files to be partially rendered due
to the fact that a watch and subsequent render are triggered _before_
the file has finished being written to.
