### PR TITLE
v6.48.1. Bugfix. Improvement.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## History
 
+- v6.48.1 August 6, 2013
+	- Fixed [issue #584](https://github.com/bevry/docpad/issues/584)
+		- Now the output filename of a file without an extension will remain unchanged
+	- Added a test for the aforementioned issue
+
 - v6.48.0 August 5, 2013
 	- Moved `regenerateEvery` timer into `generate` rather than `setConfig` to avoid action stacking
 	- DocPad will now warn you when your project's local DocPad version does not match the global version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "docpad",
-	"version": "6.48.0",
+	"version": "6.48.1",
 	"description": "DocPad is a language agnostic document management system. This means you write your website as documents, in whatever language you wish, and DocPad will handle the compiling, templates and layouts for you. For static documents it will generate static files, for dynamic documents it'll re-render them on each request. You can utilise DocPad by itself, or use it as a module your own custom system. It's pretty cool, and well worth checking out. We love it.",
 	"homepage": "https://github.com/bevry/docpad",
 	"installUrl": "http://docpad.org/install",
@@ -52,7 +52,8 @@
 		"Adrian Olaru <agolaru@gmail.com> (https://github.com/adrianolaru)",
 		"Richard A <richard@antecki.id.au> (https://github.com/rantecki)",
 		"Neil Taylor <neil.t@myplanetdigital.com> (https://github.com/neilbaylorrulez)",
-		"Sven Vetsch (https://github.com/disenchant)"
+		"Sven Vetsch (https://github.com/disenchant)",
+		"Chase Colman <chase@infinityatlas.com> (https://github.com/chase)"
 	],
 	"bugs": {
 		"url": "https://github.com/bevry/docpad/issues"

--- a/src/lib/util.coffee
+++ b/src/lib/util.coffee
@@ -43,8 +43,8 @@ module.exports = docpadUtil =
 		if basename is '.'+extension  # prevent: .htaccess.htaccess
 			return basename
 		else
-			return basename+(if extension then '.'+extension or '')
-
+			return basename+(if extension then '.'+extension else '')
+			
 	# get url
 	getUrl: (relativePath) ->
 		return '/'+relativePath.replace(/[\\]/g, '/')

--- a/test/out-expected/file-with-no-extension
+++ b/test/out-expected/file-with-no-extension
@@ -1,0 +1,1 @@
+The filename should be unchanged

--- a/test/src/files/file-with-no-extension
+++ b/test/src/files/file-with-no-extension
@@ -1,0 +1,1 @@
+The filename should be unchanged


### PR DESCRIPTION
- v6.48.1 August 6, 2013
  - Fixed [issue #584](https://github.com/bevry/docpad/issues/584)
    - Now the output filename of a file without an extension will remain unchanged
  - Added a test for the aforementioned issue
