### PR TITLE
fix: resetCollections->"has no method 'add'"

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -1860,7 +1860,8 @@ class DocPad extends EventEmitterGrouped
 
 		# Perform a complete clean of our collections
 		database.reset([])
-		meta = @getBlock('meta').reset([])
+		meta = @getBlock('meta')
+		meta.reset([])
 		meta.add("""<meta name="generator" content="DocPad v#{docpad.getVersion()}" />""")  if docpad.getConfig().poweredByDocPad isnt false
 		@getBlock('scripts').reset([])
 		@getBlock('styles').reset([])


### PR DESCRIPTION
has no method 'add' for docpad-actions create

reset wasn't returning a collection. So have split the chained call from

```
@getBlock('meta').reset([])"
```

to

```
meta = @getBlock('meta')
meta.reset([])
```

tests now passing again ;)
