### PR TITLE
Shows docpad root path when running "docpad --version"

### DIFF
--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -24,7 +24,7 @@ class ConsoleInterface
 
 		commander
 			.version(
-				docpad.getVersionString()
+				docpad.getVersionString() + ' ' + pathUtil.join(__dirname, "../../..")
 			)
 			.option(
 				'-o, --out <outPath>'


### PR DESCRIPTION
Works for local and global instances
