### PR TITLE
Fixed markdown failing tests

### DIFF
--- a/test/out-expected/extension-rendered-hack.html
+++ b/test/out-expected/extension-rendered-hack.html
@@ -1,1 +1,1 @@
-<h1>This should be rendered to html</h1>
+<h1 id="this-should-be-rendered-to-html">This should be rendered to html</h1>

--- a/test/out-expected/h5bp-document.html
+++ b/test/out-expected/h5bp-document.html
@@ -26,7 +26,7 @@
 
 	<header></header>
 	<article>
-		<h2>Not sure what to do now? Here&#39;s some useful links:</h2>
+		<h2 id="not-sure-what-to-do-now-here-s-some-useful-links-">Not sure what to do now? Here&#39;s some useful links:</h2>
 <ul>
 <li><a href="http://docpad.org/docs">DocPad Documentation</a></li>
 <li><a href="irc://irc.freenode.net/docpad">IRC Chat Room</a></li>

--- a/test/out-expected/render-single-extensions-true.md
+++ b/test/out-expected/render-single-extensions-true.md
@@ -1,1 +1,1 @@
-<h1>This should be rendered to html</h1>
+<h1 id="this-should-be-rendered-to-html">This should be rendered to html</h1>


### PR DESCRIPTION
Failing because out-expected H tags were missing the generated id's
