### PR TITLE
Ensuring the pluginPort for tests is a number < 65,536

### DIFF
--- a/src/lib/testers.coffee
+++ b/src/lib/testers.coffee
@@ -10,7 +10,8 @@ _ = require('lodash')
 DocPad = require('./docpad')
 
 # Prepare
-pluginPort = 2000+String((new Date()).getTime()).substr(-6,4)
+# We want the plugn port to be a semi-random number above 2000
+pluginPort = 2000 + parseInt(String(Date.now()).substr(-6, 4))
 testers = {
 	CSON,
 	DocPad


### PR DESCRIPTION
The previous code created strings that were at least 20,000,000 which node then treated as file sockets. This makes failing tests slightly harder to debug because you can't just open the url in a browser.

This changes the time back into a number after slicing out a few digits.
