### PR TITLE
Added forced reduction to Date object

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -4509,8 +4509,8 @@ class DocPad extends EventEmitterGrouped
 
 		else
 			# ETag: `"<size>-<mtime>"`
-			ctime = document.get('date')    # use the date or mtime, it should always exist
-			mtime = document.get('wtime')   # use the last generate time, it may not exist though
+			ctime = new Date(document.get('date'))    # use the date or mtime, it should always exist
+			mtime = new Date(document.get('wtime'))   # use the last generate time, it may not exist though
 			stat = document.getStat()
 			res.setHeaderIfMissing('ETag', '"' + stat.size + '-' + Number(mtime) + '"')  if mtime
 


### PR DESCRIPTION
Hi.

I use Mac OS and I have some issues. 

My meta-data for index.hmtl

```

---
title: ''
layout: 'default'
dynamic: true
standalone: true

---
```

When I run `docpad server --env ru` files with css and javascript not loaded, because I see 500 error. 

In console I have this: `TypeError: Object 2014-01-25T14:49:35.294Z has no method 'toUTCString'`
In Headers on page I saw that Etag have not valid value.

Response Headers

```
Connection:keep-alive
Content-Length:3858
Content-Type:text/html
Date:Sat, 25 Jan 2014 12:56:27 GMT
ETag:"5226-NaN"
X-Powered-By:Express, DocPad v6.60.3
```

It fix make Date object from mtime date always.
