### PR TITLE
add null check for stat https://github.com/docpad/docpad-plugin-tags/issues/3

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -4512,7 +4512,7 @@ class DocPad extends EventEmitterGrouped
 			ctime = document.get('date')    # use the date or mtime, it should always exist
 			mtime = document.get('wtime')   # use the last generate time, it may not exist though
 			stat = document.getStat()
-			res.setHeaderIfMissing('ETag', '"' + stat.size + '-' + Number(mtime) + '"')  if mtime
+			res.setHeaderIfMissing('ETag', '"' + stat.size + '-' + Number(mtime) + '"')  if mtime and stat
 
 			# Date
 			res.setHeaderIfMissing('Date', ctime.toUTCString())  if ctime


### PR DESCRIPTION
when using the tags plugin, this line throws sometimes an uncaught exception because `stat` is null  
fixes https://github.com/docpad/docpad-plugin-tags/issues/3

node v0.10.24
npm 1.3.21
docpad: 6.60.3
docpad-plugin-tags 2.0.7
