### PR TITLE
adds css front matter escapes

### DIFF
--- a/src/lib/models/document.coffee
+++ b/src/lib/models/document.coffee
@@ -122,6 +122,9 @@ class DocumentModel extends FileModel
 				# allow some space
 				^\s*
 
+				# skip any css espaces if present
+				(?:/\*{1,}|) # match opening css espace seq 1 times
+
 				# discover our seperator
 				(
 					([^\s\d\w])\2{2,} # match a symbol character repeated 3 or more times
@@ -142,6 +145,9 @@ class DocumentModel extends FileModel
 
 				# match our seperator (the first group) exactly
 				\1
+
+				# skip closing css espaces
+				(?:\*/|){1,} # match closing css espace seq 1 times
 				///
 
 			# Extract Meta Data

--- a/test/out-expected/css-front-matter-escapes.css
+++ b/test/out-expected/css-front-matter-escapes.css
@@ -1,0 +1,3 @@
+.test {
+  color: red;
+}

--- a/test/src/documents/css-front-matter-escapes.css
+++ b/test/src/documents/css-front-matter-escapes.css
@@ -1,0 +1,13 @@
+/*---cson
+author: super ted
+guide: """
+#heading
+
+content
+
+"""
+---*/
+
+.test {
+  color: red;
+}


### PR DESCRIPTION
I have a scenario with sass files where if front matter exists in a scss file and I then try to compile it outside of docpad an error "Syntax error: Invalid CSS after "-": expected number or function, was "--cson""

This is caused by sass not being able to recognise the 3 char front matter sequences like ### or ---.

I've created a solution that escapes the front matter using css commenting like this:

``` css
/*---cson
author: "super ted"
info: "123"
---*/
```

The advantages of this also allows sass\css editors to render the document correctly without reporting errors and discolouring the output.
