### PR TITLE
Fixed afefs name to safefs when writing cache file

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -3642,7 +3642,7 @@ class DocPad extends EventEmitterGrouped
 				models: (model.getAttributes()  for model in database.models)
 			databaseDataDump = JSON.stringify(databaseData, null, '  ')
 			docpad.log 'info', util.format(locale.databaseCacheWrite, databaseData.models.length)
-			return afefs.writeFile(config.databaseCachePath, databaseDataDump, complete)
+			return safefs.writeFile(config.databaseCachePath, databaseDataDump, complete)
 
 
 		# Run


### PR DESCRIPTION
Tried today to run build of my site and found this problem. When docpad is trying write the cache file, it crashes. 
