### PR TITLE
Use colors in `inspect`

### DIFF
--- a/locale/en.cson
+++ b/locale/en.cson
@@ -177,6 +177,7 @@
 	consoleOptionPort: "a custom port to use for the server <port>"
 	consoleOptionProfile: "enable profiling"
 	consoleOptionOffline: "don't do any remote requests"
+	consoleOptionNoColor: "don't colorize terminal output"
 	consoleOptionSilent: "don't use any prompts"
 	consoleOptionCache: "use the database cache ability to speed up docpad"
 

--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -2166,7 +2166,7 @@ class DocPad extends EventEmitterGrouped
 
 		# Handle
 		@error err, 'err', ->
-			process.stderr.write require('util').inspect(err.stack or err.message)
+			process.stderr.write docpadUtil.inspect(err.stack or err.message)
 			docpad.destroy()
 
 		# Chain

--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -5,6 +5,7 @@ safeps = require('safeps')
 {TaskGroup} = require('taskgroup')
 extendr = require('extendr')
 promptly = require('promptly')
+docpadUtil = require('../util')
 
 # Console Interface
 class ConsoleInterface
@@ -245,7 +246,7 @@ class ConsoleInterface
 		locale = docpad.getLocale()
 
 		# Error?
-		process.stderr.write(require('util').inspect(err.stack or err.message or err))  if err
+		process.stderr.write(docpadUtil.inspect(err.stack or err.message or err))  if err
 		# ^ @TODO document we we use process.stderr.write instead of console.log here
 
 		# Log Shutdown
@@ -254,7 +255,7 @@ class ConsoleInterface
 		# Destroy docpad
 		docpad.destroy (err) ->
 			# Error?
-			process.stderr.write(require('util').inspect(err.stack or err.message or err))  if err
+			process.stderr.write(docpadUtil.inspect(err.stack or err.message or err))  if err
 			# ^ @TODO document we we use process.stderr.write instead of console.log here
 
 			# don't force exit, it should occur naturally
@@ -622,7 +623,7 @@ class ConsoleInterface
 		@
 
 	info: (next) =>
-		info = require('util').inspect(@docpad.config)
+		info = docpadUtil.inspect(@docpad.config)
 		console.log(info)
 		next()
 		@

--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -61,6 +61,10 @@ class ConsoleInterface
 				locale.consoleOptionCache
 			)
 			.option(
+				'--no-color'
+				locale.consoleOptionNoColor
+			)
+			.option(
 				'--silent'
 				locale.consoleOptionSilent
 			)

--- a/src/lib/util.coffee
+++ b/src/lib/util.coffee
@@ -10,6 +10,9 @@ module.exports = docpadUtil =
 	
 	# Inspect in color
 	inspect: (obj, opts={colors:true}) ->
+		# disable colors for non-terminal output
+		if process.stdout.isTTY is false or process.stderr.isTTY is false
+			opts.colors = false
 		util.inspect(obj, opts)
 	
 	# Standard Encodings

--- a/src/lib/util.coffee
+++ b/src/lib/util.coffee
@@ -3,9 +3,15 @@ _ = require('lodash')
 {extractOptsAndCallback} = require('extract-opts')
 {TaskGroup} = require('taskgroup')
 pathUtil = require('path')
+util = require('util')
 
 # Export
 module.exports = docpadUtil =
+	
+	# Inspect in color
+	inspect: (obj, opts={colors:true}) ->
+		util.inspect(obj, opts)
+	
 	# Standard Encodings
 	isStandardEncoding: (encoding) ->
 		return encoding.toLowerCase() in ['ascii', 'utf8', 'utf-8']


### PR DESCRIPTION
* In `src/lib/util` (typically required as “`docpadUtil`”): Added a simple wrapper around the standard `util.inspect` function (with `{colors:true}` set by default)
* Changed calls to `util.inspect` to `docpadUtil.inspect`


Now, when the user types `docpad info`, their config info is much more readable! ☺ 