### PR TITLE
Adds coffee compilation step to install target.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -124,6 +124,19 @@ actions =
 		# Start
 		step1()
 
+	compilelib: (opts,next) ->
+		# Prepare
+		(next = opts; opts = {})  unless next?
+
+		step1 = ->
+			return step2()  if !config.COFFEE_SRC_PATH or !fsUtil.existsSync(COFFEE)
+			console.log('coffee compile lib')
+			spawn(NODE, [COFFEE, '-co', config.COFFEE_OUT_PATH, config.COFFEE_SRC_PATH], {stdio:'inherit', cwd:APP_PATH}).on('close', safe next, step2)
+		step2 = next
+
+		# Start
+		step1()
+
 	compile: (opts,next) ->
 		# Prepare
 		(next = opts; opts = {})  unless next?
@@ -133,9 +146,8 @@ actions =
 			console.log('cake install')
 			actions.install(opts, safe next, step2)
 		step2 = ->
-			return step3()  if !config.COFFEE_SRC_PATH or !fsUtil.existsSync(COFFEE)
-			console.log('coffee compile')
-			spawn(NODE, [COFFEE, '-co', config.COFFEE_OUT_PATH, config.COFFEE_SRC_PATH], {stdio:'inherit', cwd:APP_PATH}).on('close', safe next, step3)
+			console.log('coffee compile lib')
+			actions.compilelib(opts, safe next, step3)
 		step3 = ->
 			return step4()  if !config.DOCPAD_SRC_PATH or !fsUtil.existsSync(DOCPAD)
 			console.log('docpad generate')
@@ -244,7 +256,8 @@ actions =
 commands =
 	clean:       'clean up instance'
 	install:     'install dependencies'
-	compile:     'compile our files (runs install)'
+	compilelib:  'compile docpad lib files'
+	compile:     'compile docpad files (runs install/compilelib)'
 	watch:       'compile our files initially, and again for each change (runs install)'
 	test:        'run our tests (runs compile)'
 	prepublish:  'prepare our package for publishing'

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "ambi": "~2.2.0",
     "backbone": "1.1.2",
     "bal-util": "~2.4.0",
+    "coffee-script": "~1.7.1",
     "caterpillar": "~2.0.7",
     "caterpillar-filter": "~2.0.3",
     "caterpillar-human": "~2.1.1",
@@ -169,6 +170,7 @@
     "docpad-trace": "./bin/docpad-trace"
   },
   "scripts": {
+    "install": "cake compilelib",
     "test": "node ./out/test/everything-test.js"
   },
   "main": "./out/main.js",


### PR DESCRIPTION
This diff:
- introduces a new `compilelib` cake action to compile docpad's lib files
- introduces a new npm `install` hook which uses the new cake action.

Before the patch, `out` could not be found because docpad's coffee files (in `src/lib`) weren't compiled on install:

``````
$ npm install git://github.com/ArnaudBrousseau/docpad.git#master

> ambi@2.2.0 preinstall /Users/arnaud/git/docpad-project/node_modules/docpad/node_modules/ambi
> node ./cyclic.js

[snip]

docpad@6.69.0 node_modules/docpad
├── lazy-require@1.0.0
├── eachr@2.0.2
├── extendonclass@1.0.1
├── extendr@2.1.0
├── extract-opts@2.2.0
├── commander@2.2.0
├── caterpillar-filter@2.0.3
├── event-emitter-grouped@2.4.3
├── envfile@1.0.0
├── getmac@1.0.6
├── ambi@2.2.0
├── longjohn@0.2.4
├── mime@1.2.11
├── typechecker@2.0.8
├── progressbar@1.0.3 (progress@1.1.2)
├── safefs@3.1.1 (graceful-fs@2.0.3)
├── semver@2.3.2
├── safeps@2.2.12 (taskgroup@3.4.0)
├── ignorefs@1.0.0 (ignorepatterns@1.0.1)
├── caterpillar-human@2.1.2 (ansistyles@0.1.3, ansicolors@0.3.2)
├── promptly@0.2.0 (read@1.0.5)
├── bal-util@2.4.1 (ambi@2.1.6, taskgroup@3.3.9)
├── backbone@1.1.2 (underscore@1.6.0)
├── watchr@2.4.11 (taskgroup@3.3.9)
├── encoding@0.1.8 (iconv-lite@0.4.4)
├── istextorbinary@1.0.0 (binaryextensions@1.0.0, textextensions@1.0.0, safefs@3.0.6)
├── jschardet@1.1.0
├── taskgroup@4.0.3 (csextends@1.0.3)
├── lodash@2.4.1
├── cson@1.6.0 (requirefresh@1.1.2, coffee-script@1.7.1, js2coffee@0.3.1)
├── caterpillar@2.0.7 (readable-stream@1.1.13-1)
├── superagent@0.18.2 (extend@1.2.1, qs@0.6.6, methods@1.0.1, cookiejar@2.0.1, component-emitter@1.1.2, reduce-component@1.0.1, debug@1.0.4, readable-stream@1.0.27-1, formidable@1.0.14, form-data@0.1.3)
├── yamljs@0.1.5 (argparse@0.1.15, glob@3.1.21)
├── query-engine@1.5.7
└── express@3.4.8 (methods@0.1.0, merge-descriptors@0.0.1, range-parser@0.0.4, cookie-signature@1.0.1, debug@0.8.1, fresh@0.2.0, buffer-crc32@0.2.1, cookie@0.1.0, send@0.1.4, mkdirp@0.3.5, commander@1.3.2, connect@2.12.0)

$ node_modules/.bin/docpad --version

module.js:340
    throw err;
          ^
Error: Cannot find module '../out/bin/docpad'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/arnaud/git/docpad-project/node_modules/docpad/bin/docpad:2:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)```
``````

After this patch, everything runs smoothly (note the new lines `coffee compile lib`, `OK`):

```
$ npm install git://github.com/ArnaudBrousseau/docpad.git#coffee-compile-on-install

> ambi@2.2.0 preinstall /Users/arnaud/git/docpad-project/node_modules/docpad/node_modules/ambi
> node ./cyclic.js

[snip]

\
> docpad@6.69.0 install /Users/arnaud/git/docpad-project/node_modules/docpad
> cake compilelib

coffee compile lib
OK
docpad@6.69.0 node_modules/docpad
├── lazy-require@1.0.0
├── eachr@2.0.2
├── extendonclass@1.0.1
├── extendr@2.1.0
├── extract-opts@2.2.0
├── commander@2.2.0
├── caterpillar-filter@2.0.3
├── event-emitter-grouped@2.4.3
├── envfile@1.0.0
├── getmac@1.0.6
├── ambi@2.2.0
├── longjohn@0.2.4
├── mime@1.2.11
├── typechecker@2.0.8
├── semver@2.3.2
├── ignorefs@1.0.0 (ignorepatterns@1.0.1)
├── bal-util@2.4.1 (ambi@2.1.6, taskgroup@3.3.9)
├── safeps@2.2.12 (taskgroup@3.4.0)
├── watchr@2.4.11 (taskgroup@3.3.9)
├── safefs@3.1.1 (graceful-fs@2.0.3)
├── progressbar@1.0.3 (progress@1.1.2)
├── caterpillar-human@2.1.2 (ansistyles@0.1.3, ansicolors@0.3.2)
├── backbone@1.1.2 (underscore@1.6.0)
├── encoding@0.1.8 (iconv-lite@0.4.4)
├── jschardet@1.1.0
├── istextorbinary@1.0.0 (binaryextensions@1.0.0, textextensions@1.0.0, safefs@3.0.6)
├── promptly@0.2.0 (read@1.0.5)
├── taskgroup@4.0.3 (csextends@1.0.3)
├── lodash@2.4.1
├── cson@1.6.0 (requirefresh@1.1.2, js2coffee@0.3.1)
├── coffee-script@1.7.1 (mkdirp@0.3.5)
├── superagent@0.18.2 (extend@1.2.1, qs@0.6.6, methods@1.0.1, cookiejar@2.0.1, component-emitter@1.1.2, reduce-component@1.0.1, debug@1.0.4, formidable@1.0.14, form-data@0.1.3, readable-stream@1.0.27-1)
├── caterpillar@2.0.7 (readable-stream@1.1.13-1)
├── query-engine@1.5.7
├── yamljs@0.1.5 (glob@3.1.21, argparse@0.1.15)
└── express@3.4.8 (methods@0.1.0, merge-descriptors@0.0.1, debug@0.8.1, cookie-signature@1.0.1, range-parser@0.0.4, fresh@0.2.0, buffer-crc32@0.2.1, cookie@0.1.0, send@0.1.4, mkdirp@0.3.5, commander@1.3.2, connect@2.12.0)

$ node_modules/.bin/docpad --version
v6.69.0 (local installation: /Users/arnaud/git/docpad-project/node_modules/docpad)
```

Is there something I'm missing? Any reason not to compile lib files on install? Any better way to do it?
I'm completely new to docpad as a contributor (first pull request!) so any guidance/comments/suggestions are welcome!
