### PR TITLE
README - Fix outdated repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 <!-- BADGES/ -->
 
-[![Build Status](http://img.shields.io/travis-ci/bevry/docpad.png?branch=master)](http://travis-ci.org/bevry/docpad "Check this project's build status on TravisCI")
+[![Build Status](http://img.shields.io/travis-ci/docpad/docpad.png?branch=master)](http://travis-ci.org/docpad/docpad "Check this project's build status on TravisCI")
 [![NPM version](http://badge.fury.io/js/docpad.png)](https://npmjs.org/package/docpad "View this project on NPM")
-[![Dependency Status](https://david-dm.org/bevry/docpad.png?theme=shields.io)](https://david-dm.org/bevry/docpad)
-[![Development Dependency Status](https://david-dm.org/bevry/docpad/dev-status.png?theme=shields.io)](https://david-dm.org/bevry/docpad#info=devDependencies)<br/>
+[![Dependency Status](https://david-dm.org/docpad/docpad.png?theme=shields.io)](https://david-dm.org/docpad/docpad)
+[![Development Dependency Status](https://david-dm.org/docpad/docpad/dev-status.png?theme=shields.io)](https://david-dm.org/docpad/docpad#info=devDependencies)<br/>
 [![Gittip donate button](http://img.shields.io/gittip/docpad.png)](https://www.gittip.com/docpad/ "Donate weekly to this project using Gittip")
 [![Flattr donate button](http://img.shields.io/flattr/donate.png?color=yellow)](http://flattr.com/thing/344188/balupton-on-Flattr "Donate monthly to this project using Flattr")
 [![PayPayl donate button](http://img.shields.io/paypal/donate.png?color=yellow)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=QB8GQPZAH84N6 "Donate once-off to this project using Paypal")
@@ -105,7 +105,7 @@ Here are some quick links to help you get started:
 <!-- HISTORY/ -->
 
 ## History
-[Discover the change history by heading on over to the `HISTORY.md` file.](https://github.com/bevry/docpad/blob/master/HISTORY.md#files)
+[Discover the change history by heading on over to the `HISTORY.md` file.](https://github.com/docpad/docpad/blob/master/HISTORY.md#files)
 
 <!-- /HISTORY -->
 
@@ -114,7 +114,7 @@ Here are some quick links to help you get started:
 
 ## Contribute
 
-[Discover how you can contribute by heading on over to the `CONTRIBUTING.md` file.](https://github.com/bevry/docpad/blob/master/CONTRIBUTING.md#files)
+[Discover how you can contribute by heading on over to the `CONTRIBUTING.md` file.](https://github.com/docpad/docpad/blob/master/CONTRIBUTING.md#files)
 
 <!-- /CONTRIBUTE -->
 
@@ -148,44 +148,44 @@ Become a sponsor!
 
 These amazing people have contributed code to this project:
 
-- [Aaron Powell](https://github.com/aaronpowell) <me@aaron-powell.com> — [view contributions](https://github.com/bevry/docpad/commits?author=aaronpowell)
-- [Adrian Olaru](https://github.com/adrianolaru) <agolaru@gmail.com> — [view contributions](https://github.com/bevry/docpad/commits?author=adrianolaru)
-- [Alex](https://github.com/amesarosh) — [view contributions](https://github.com/bevry/docpad/commits?author=amesarosh)
-- [Alroniks](https://github.com/Alroniks) — [view contributions](https://github.com/bevry/docpad/commits?author=Alroniks)
-- [Andrew Patton](https://github.com/acusti) <andrew@acusti.ca> — [view contributions](https://github.com/bevry/docpad/commits?author=acusti)
-- [Ashnur](https://github.com/ashnur) — [view contributions](https://github.com/bevry/docpad/commits?author=ashnur)
-- [Ben Barber](https://github.com/barberboy) — [view contributions](https://github.com/bevry/docpad/commits?author=barberboy)
-- [Benjamin Lupton](https://github.com/balupton) <b@lupton.cc> — [view contributions](https://github.com/bevry/docpad/commits?author=balupton)
-- [Bruno Héridet](https://github.com/Delapouite) — [view contributions](https://github.com/bevry/docpad/commits?author=Delapouite)
-- [Changwoo Park](https://github.com/pismute) <pismute@gmail.com> — [view contributions](https://github.com/bevry/docpad/commits?author=pismute)
-- [Chase Colman](https://github.com/chase) <chase@infinityatlas.com> — [view contributions](https://github.com/bevry/docpad/commits?author=chase)
-- [eldios](https://github.com/eldios) <lele@amicofigo.com> — [view contributions](https://github.com/bevry/docpad/commits?author=eldios)
-- [Ferrari Lee](https://github.com/Ferrari) <shiyung@gmail.com> — [view contributions](https://github.com/bevry/docpad/commits?author=Ferrari)
-- [Homme Zwaagstra](https://github.com/homme) <hrz@geodata.soton.ac.uk> — [view contributions](https://github.com/bevry/docpad/commits?author=homme)
-- [kalkin](https://github.com/kalkin) — [view contributions](https://github.com/bevry/docpad/commits?author=kalkin)
-- [Luke Hagan](https://github.com/lhagan) — [view contributions](https://github.com/bevry/docpad/commits?author=lhagan)
-- [mikeumus](https://github.com/mikeumus) — [view contributions](https://github.com/bevry/docpad/commits?author=mikeumus)
-- [Neil Taylor](https://github.com/neilbaylorrulez) <neil.t@myplanetdigital.com> — [view contributions](https://github.com/bevry/docpad/commits?author=neilbaylorrulez)
-- [nfriedly](https://github.com/nfriedly) — [view contributions](https://github.com/bevry/docpad/commits?author=nfriedly)
-- [Nick Crohn](https://github.com/ncrohn) <ncrohn@me.com> — [view contributions](https://github.com/bevry/docpad/commits?author=ncrohn)
-- [Olivier Bazoud](https://github.com/obazoud) — [view contributions](https://github.com/bevry/docpad/commits?author=obazoud)
-- [Paul Armstrong](https://github.com/paularmstrong) <paul@paularmstrongdesigns.com> — [view contributions](https://github.com/bevry/docpad/commits?author=paularmstrong)
-- [pflannery](https://github.com/pflannery) — [view contributions](https://github.com/bevry/docpad/commits?author=pflannery)
-- [radiodario](https://github.com/radiodario) — [view contributions](https://github.com/bevry/docpad/commits?author=radiodario)
-- [Richard A](https://github.com/rantecki) <richard@antecki.id.au> — [view contributions](https://github.com/bevry/docpad/commits?author=rantecki)
-- [ruemic](https://github.com/ruemic) — [view contributions](https://github.com/bevry/docpad/commits?author=ruemic)
-- [Sorin Ionescu](https://github.com/sorin-ionescu) <sorin.ionescu@gmail.com> — [view contributions](https://github.com/bevry/docpad/commits?author=sorin-ionescu)
-- [Stefan](https://github.com/stegrams) — [view contributions](https://github.com/bevry/docpad/commits?author=stegrams)
-- [Sven Vetsch](https://github.com/disenchant) — [view contributions](https://github.com/bevry/docpad/commits?author=disenchant)
-- [timaschew](https://github.com/timaschew) — [view contributions](https://github.com/bevry/docpad/commits?author=timaschew)
-- [Todd Anglin](https://github.com/toddanglin) — [view contributions](https://github.com/bevry/docpad/commits?author=toddanglin)
-- [ttamminen](https://github.com/ttamminen) — [view contributions](https://github.com/bevry/docpad/commits?author=ttamminen)
-- [unframework](https://github.com/unframework) — [view contributions](https://github.com/bevry/docpad/commits?author=unframework)
-- [Vladislav Botvin](https://github.com/darrrk) <darkvlados@me.com> — [view contributions](https://github.com/bevry/docpad/commits?author=darrrk)
-- [Zearin](https://github.com/Zearin) — [view contributions](https://github.com/bevry/docpad/commits?author=Zearin)
-- [Zhao Lei](https://github.com/firede) <aicoylei@gmail.com> — [view contributions](https://github.com/bevry/docpad/commits?author=firede)
+- [Aaron Powell](https://github.com/aaronpowell) <me@aaron-powell.com> — [view contributions](https://github.com/docpad/docpad/commits?author=aaronpowell)
+- [Adrian Olaru](https://github.com/adrianolaru) <agolaru@gmail.com> — [view contributions](https://github.com/docpad/docpad/commits?author=adrianolaru)
+- [Alex](https://github.com/amesarosh) — [view contributions](https://github.com/docpad/docpad/commits?author=amesarosh)
+- [Alroniks](https://github.com/Alroniks) — [view contributions](https://github.com/docpad/docpad/commits?author=Alroniks)
+- [Andrew Patton](https://github.com/acusti) <andrew@acusti.ca> — [view contributions](https://github.com/docpad/docpad/commits?author=acusti)
+- [Ashnur](https://github.com/ashnur) — [view contributions](https://github.com/docpad/docpad/commits?author=ashnur)
+- [Ben Barber](https://github.com/barberboy) — [view contributions](https://github.com/docpad/docpad/commits?author=barberboy)
+- [Benjamin Lupton](https://github.com/balupton) <b@lupton.cc> — [view contributions](https://github.com/docpad/docpad/commits?author=balupton)
+- [Bruno Héridet](https://github.com/Delapouite) — [view contributions](https://github.com/docpad/docpad/commits?author=Delapouite)
+- [Changwoo Park](https://github.com/pismute) <pismute@gmail.com> — [view contributions](https://github.com/docpad/docpad/commits?author=pismute)
+- [Chase Colman](https://github.com/chase) <chase@infinityatlas.com> — [view contributions](https://github.com/docpad/docpad/commits?author=chase)
+- [eldios](https://github.com/eldios) <lele@amicofigo.com> — [view contributions](https://github.com/docpad/docpad/commits?author=eldios)
+- [Ferrari Lee](https://github.com/Ferrari) <shiyung@gmail.com> — [view contributions](https://github.com/docpad/docpad/commits?author=Ferrari)
+- [Homme Zwaagstra](https://github.com/homme) <hrz@geodata.soton.ac.uk> — [view contributions](https://github.com/docpad/docpad/commits?author=homme)
+- [kalkin](https://github.com/kalkin) — [view contributions](https://github.com/docpad/docpad/commits?author=kalkin)
+- [Luke Hagan](https://github.com/lhagan) — [view contributions](https://github.com/docpad/docpad/commits?author=lhagan)
+- [mikeumus](https://github.com/mikeumus) — [view contributions](https://github.com/docpad/docpad/commits?author=mikeumus)
+- [Neil Taylor](https://github.com/neilbaylorrulez) <neil.t@myplanetdigital.com> — [view contributions](https://github.com/docpad/docpad/commits?author=neilbaylorrulez)
+- [nfriedly](https://github.com/nfriedly) — [view contributions](https://github.com/docpad/docpad/commits?author=nfriedly)
+- [Nick Crohn](https://github.com/ncrohn) <ncrohn@me.com> — [view contributions](https://github.com/docpad/docpad/commits?author=ncrohn)
+- [Olivier Bazoud](https://github.com/obazoud) — [view contributions](https://github.com/docpad/docpad/commits?author=obazoud)
+- [Paul Armstrong](https://github.com/paularmstrong) <paul@paularmstrongdesigns.com> — [view contributions](https://github.com/docpad/docpad/commits?author=paularmstrong)
+- [pflannery](https://github.com/pflannery) — [view contributions](https://github.com/docpad/docpad/commits?author=pflannery)
+- [radiodario](https://github.com/radiodario) — [view contributions](https://github.com/docpad/docpad/commits?author=radiodario)
+- [Richard A](https://github.com/rantecki) <richard@antecki.id.au> — [view contributions](https://github.com/docpad/docpad/commits?author=rantecki)
+- [ruemic](https://github.com/ruemic) — [view contributions](https://github.com/docpad/docpad/commits?author=ruemic)
+- [Sorin Ionescu](https://github.com/sorin-ionescu) <sorin.ionescu@gmail.com> — [view contributions](https://github.com/docpad/docpad/commits?author=sorin-ionescu)
+- [Stefan](https://github.com/stegrams) — [view contributions](https://github.com/docpad/docpad/commits?author=stegrams)
+- [Sven Vetsch](https://github.com/disenchant) — [view contributions](https://github.com/docpad/docpad/commits?author=disenchant)
+- [timaschew](https://github.com/timaschew) — [view contributions](https://github.com/docpad/docpad/commits?author=timaschew)
+- [Todd Anglin](https://github.com/toddanglin) — [view contributions](https://github.com/docpad/docpad/commits?author=toddanglin)
+- [ttamminen](https://github.com/ttamminen) — [view contributions](https://github.com/docpad/docpad/commits?author=ttamminen)
+- [unframework](https://github.com/unframework) — [view contributions](https://github.com/docpad/docpad/commits?author=unframework)
+- [Vladislav Botvin](https://github.com/darrrk) <darkvlados@me.com> — [view contributions](https://github.com/docpad/docpad/commits?author=darrrk)
+- [Zearin](https://github.com/Zearin) — [view contributions](https://github.com/docpad/docpad/commits?author=Zearin)
+- [Zhao Lei](https://github.com/firede) <aicoylei@gmail.com> — [view contributions](https://github.com/docpad/docpad/commits?author=firede)
 
-[Become a contributor!](https://github.com/bevry/docpad/blob/master/CONTRIBUTING.md#files)
+[Become a contributor!](https://github.com/docpad/docpad/blob/master/CONTRIBUTING.md#files)
 
 <!-- /BACKERS -->
 


### PR DESCRIPTION
The indicators for both the Travis.io build status and the David.dm dependency status were previously broken (appearing either as 'inaccessible' or just returning 404), as were the URLS they were linking to.

This commit fixes the indicators as well as a number of other links throughout README.md which were pointing to the old /bevry fork.
