### PR TITLE
Fully remove previous ID when performing `file.clone()`

### DIFF
--- a/src/lib/models/file.coffee
+++ b/src/lib/models/file.coffee
@@ -132,9 +132,9 @@ class FileModel extends Model
 
 		# Clean up
 		delete attrs.id
-		delete attrs.meta.id;
-		delete opts.meta.id;
-		delete opts.meta.attributes.id;
+		delete attrs.meta.id
+		delete opts.meta.id
+		delete opts.meta.attributes.id
 
 		# Clone
 		clonedModel = new @klass(attrs, opts)


### PR DESCRIPTION
This fixes https://github.com/docpad/docpad-plugin-multiplelayouts/issues/9 - I believe all 4 deletions are necessary due to the way things get munged together.
