### PR TITLE
Fixing error message when docpad can't find the layout

### DIFF
--- a/src/lib/models/document.coffee
+++ b/src/lib/models/document.coffee
@@ -503,6 +503,7 @@ class DocumentModel extends FileModel
 
 			# We had a layout, but it is missing
 			else if file.hasLayout()
+					layoutSelector = file.get('layout')
 					err = new Error(util.format(locale.documentMissingLayoutError, layoutSelector, filePath))
 					return next(err, content)
 


### PR DESCRIPTION
I was getting the error

```
ReferenceError: layoutSelector is not defined
  at c:\path\to\project\node_modules\docpad\out\lib\models\document.js:398:74
  [...]
```

Instead of the more helpful `Error: Could not find the layout service-landing-page on /user-modeling.html` because `layoutSelector` wasn't defined in the `renderLayouts` function.

This fixes that.
