### PR TITLE
Fixed RendererTester Issue

### DIFF
--- a/src/lib/testers.coffee
+++ b/src/lib/testers.coffee
@@ -242,8 +242,10 @@ class RendererTester extends PluginTester
 
 						# Check we have the same files
 						test 'same files', ->
+							outDifferenceKeys = _.difference(outExpectedResultsKeys, outResultsKeys)
+							expect(outDifferenceKeys, 'The following file was not generated').to.be.empty
 							outDifferenceKeys = _.difference(outResultsKeys, outExpectedResultsKeys)
-							expect(outDifferenceKeys).to.be.empty
+							expect(outDifferenceKeys, 'The following file was generated and should not have been').to.be.empty
 
 						# Check the contents of those files match
 						outResultsKeys.forEach (key) ->

--- a/src/lib/testers.coffee
+++ b/src/lib/testers.coffee
@@ -243,7 +243,7 @@ class RendererTester extends PluginTester
 						# Check we have the same files
 						test 'same files', ->
 							outDifferenceKeys = _.difference(outExpectedResultsKeys, outResultsKeys)
-							expect(outDifferenceKeys, 'The following file(s) was not generated').to.be.empty
+							expect(outDifferenceKeys, 'The following file(s) should have been generated').to.be.empty
 							outDifferenceKeys = _.difference(outResultsKeys, outExpectedResultsKeys)
 							expect(outDifferenceKeys, 'The following file(s) should not have been generated').to.be.empty
 

--- a/src/lib/testers.coffee
+++ b/src/lib/testers.coffee
@@ -245,7 +245,7 @@ class RendererTester extends PluginTester
 							outDifferenceKeys = _.difference(outExpectedResultsKeys, outResultsKeys)
 							expect(outDifferenceKeys, 'The following file(s) was not generated').to.be.empty
 							outDifferenceKeys = _.difference(outResultsKeys, outExpectedResultsKeys)
-							expect(outDifferenceKeys, 'The following file(s) was generated and should not have been').to.be.empty
+							expect(outDifferenceKeys, 'The following file(s) should not have been generated').to.be.empty
 
 						# Check the contents of those files match
 						outResultsKeys.forEach (key) ->

--- a/src/lib/testers.coffee
+++ b/src/lib/testers.coffee
@@ -243,9 +243,9 @@ class RendererTester extends PluginTester
 						# Check we have the same files
 						test 'same files', ->
 							outDifferenceKeys = _.difference(outExpectedResultsKeys, outResultsKeys)
-							expect(outDifferenceKeys, 'The following file was not generated').to.be.empty
+							expect(outDifferenceKeys, 'The following file(s) was not generated').to.be.empty
 							outDifferenceKeys = _.difference(outResultsKeys, outExpectedResultsKeys)
-							expect(outDifferenceKeys, 'The following file was generated and should not have been').to.be.empty
+							expect(outDifferenceKeys, 'The following file(s) was generated and should not have been').to.be.empty
 
 						# Check the contents of those files match
 						outResultsKeys.forEach (key) ->


### PR DESCRIPTION
RendererTester when it was testing that all the files were matching from the out-expected folder it wasn't checking for files that were not generated. It was only checking files that shouldn't have been generated. I fixed it so it checks both. I also added a little messaging to make it easy to tell what went wrong.