### PR TITLE
userConfigString is now used

### DIFF
--- a/src/lib/docpad.coffee
+++ b/src/lib/docpad.coffee
@@ -1724,8 +1724,8 @@ class DocPad extends EventEmitterGrouped
 		extendr.extend(@userConfig, data)  if data
 
 		# Convert to CSON
-		result = CSON.stringify(@userConfig)
-		return next?(err)  if result instanceof Error
+		userConfigString = CSON.stringify(@userConfig)
+		return next?(err)  if userConfigString instanceof Error
 
 		# Write it
 		safefs.writeFile userConfigPath, userConfigString, 'utf8', (err) ->


### PR DESCRIPTION
Without this fix, docpad continually fails to run while attempting to write an unitialized userconfigString. This fix resolves a regression introduced in 6.70