### PR TITLE
correct spelling for 'occurring'

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1332,7 +1332,7 @@
 ## v6.11.1 November 16, 2012
 - Changes made to help get the docpad server up and running as soon as possible:
 	- `server` action is now run before `generate` action
-	- if a request is made while a generation is occuring, the request will be put on hold until the generation completes
+	- if a request is made while a generation is occurring, the request will be put on hold until the generation completes
 - We now pass the option `reset` to the `generateBefore` event
 	- Lets you know if the generation is a complete generation (`reset` is `true`) or a differential generation (`reset` is `false`)
 


### PR DESCRIPTION
http://en.wiktionary.org/wiki/occuring

Verb -  
occuring - Misspelling of occurring, the present participle of occur.
------

http://en.wiktionary.org/wiki/occur

//present participle occurring//