### PR TITLE
Checking to ensure the stdin.end function is defined before invoking it

### DIFF
--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -266,8 +266,9 @@ class ConsoleInterface
 		# Log Shutdown
 		docpad.log('info', locale.consoleShutdown)
 
-		# Close stdin
-		process.stdin.end()
+		# Close stdin if defined
+		if process.stdin && process.stdin.end
+			process.stdin.end()
 
 		# Destroy docpad
 		docpad.destroy (err) ->


### PR DESCRIPTION
See issue https://github.com/docpad/docpad/issues/1028
