### PR TITLE
Reduce priority of annoying log message.

### DIFF
--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -274,8 +274,8 @@ class ConsoleInterface
 			# Error?
 			docpadUtil.writeError(err)  if err
 
-			# Output if we are not in silent mode
-			if 6 <= logLevel
+			# Output if we are in debug mode
+			if 7 <= logLevel
 				# Note any requests that are still active
 				activeRequests = process._getActiveRequests()
 				if activeRequests?.length


### PR DESCRIPTION
"Waiting on the handles/requests" is now logged at debug level, rather
than default level.

This is what disappears:

```
[ WriteStream {
    _connecting: false,
    _hadError: false,
    _handle: 
     TTY {
       _externalStream: {},
       fd: 9,
       writeQueueSize: 0,
       ... 
       [140 more lines deleted]
```
