### PR TITLE
Catch and log errors that are thrown when stdin is closed.

### DIFF
--- a/src/lib/interfaces/console.coffee
+++ b/src/lib/interfaces/console.coffee
@@ -266,6 +266,11 @@ class ConsoleInterface
 		# Log Shutdown
 		docpad.log('info', locale.consoleShutdown)
 
+		# Handle any errors that occur when stdin is closed
+		process.stdin.on 'error', (err) ->
+			if 6 < logLevel
+				console.log err
+
 		# Close stdin
 		process.stdin.end()
 


### PR DESCRIPTION
When running DocPad via a third-party tool such as Gradle or Grunt on Windows I am seeing the following error:

```
info: The action completed successfully
info: Shutting down... cya next time!

[ERROR] [system.err] events.js:154
[ERROR] [system.err]       throw er; // Unhandled 'error' event
[ERROR] [system.err]       ^
[ERROR] [system.err]
[ERROR] [system.err] Error: The task [actions bundle: load ready Ô××  ready] just completed, but it had already completed earlier, this is unexpected. State information is:
[ERROR] [system.err] { error: 'Error: shutdown EPIPE
  at exports._errnoException (util.js:890:11)
  at Socket.onSocketFinish (net.js:221:26)
  at emitNone (events.js:80:13)
  at Socket.emit (events.js:179:7)
  at finishMaybe (_stream_writable.js:478:14)
  at endWritable (_stream_writable.js:488:3)
  at Socket.Writable.end (_stream_writable.js:453:5)
  at Socket.end(net.js:408:31)
  at ConsoleInterface.destroy (C:\\...\\node_modules\\docpad\\out\\lib\\interfaces\\console.js:111:21)
  at ConsoleInterface.destroy (C:\\...\\node_modules\\docpad\\out\\lib\\interfaces\\console.js:4:59)
```

In my case I'm using Gradle to run docpad as part of a larger build process, but I've come across a case of the same happening when the docpad build is wrapped in Grunt (https://matt.kotsenas.com/posts/running-docpad-on-azure-in-2015).

In both cases it appears that Gradle/Grunt has prematurely closed the stdin stream, so when DocPad tries to close the stream from its end on line 270 of `console.coffee` node throws an EPIPE error.

The fix I've applied is to setup an error handler on stdin immediately prior to the stream being closed to catch the error and log it out, thus preventing it from failing the build.
